### PR TITLE
Fix non-working link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Juggl has many features unique to its graph view compared to the Obsidian graph 
 You can open Juggl from the 'more options' menu on files:
 ![](https://raw.githubusercontent.com/HEmile/juggl/main/juggl/resources/open_juggl.gif)
 
-You can interact with the graph with many of the same options as in Obsidian. For further documentation, check out [juggl.io](juggl.io), where you can find information on for example [styling](https://juggl.io/Features/Styling/Styling) or the syntax of the [code fence](https://juggl.io/Features/Juggl+code+fence). 
+You can interact with the graph with many of the same options as in Obsidian. For further documentation, check out [juggl.io](https://juggl.io/), where you can find information on for example [styling](https://juggl.io/Features/Styling/Styling) or the syntax of the [code fence](https://juggl.io/Features/Juggl+code+fence). 
 You can also open the help vault with this button in Juggl:
 ![](https://raw.githubusercontent.com/HEmile/juggl/main/juggl/resources/juggl_help.gif)
 


### PR DESCRIPTION
When viewing the README at <https://github.com/HEmile/juggl>, there is a link:

```
check out [juggl.io](juggl.io), where you can find
```

Since it's a relative link, it goes to the wrong place.

This PR changes the link:

```
check out [juggl.io](https://juggl.io/), where you can find 
```

The now-absolute link goes to the correct destination.