### PR TITLE
Navigator setting should be applied to global graph settings

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -269,6 +269,7 @@ export class JugglGraphSettingsTab extends PluginSettingTab {
           .addToggle((toggle) => {
             toggle.setValue(this.plugin.settings.graphSettings.navigator)
                 .onChange((newValue) => {
+                  this.plugin.settings.globalGraphSettings.navigator = newValue;
                   this.plugin.settings.graphSettings.navigator = newValue;
                   this.plugin.saveData(this.plugin.settings);
                 });


### PR DESCRIPTION
For now it is not possible to remove navigator from global graph.