### PR TITLE
"Open Juggl" context menu option on a folder, opens global graph filtered on that folder

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -122,7 +122,7 @@ export default class JugglPlugin extends Plugin implements IJugglPlugin {
                 if (file.extension === 'md') {
                   this.openLocalGraph(file.basename);
                 } else if (file.extension === undefined) {
-                  this.openGlobalGraph(file.path);
+                  this.openGlobalGraph({ filter: "path:" + file.path });
                 } else {
                   this.openLocalGraph(file.name);
                 }
@@ -279,12 +279,9 @@ export default class JugglPlugin extends Plugin implements IJugglPlugin {
       await leaf.open(neovisView);
     }
 
-    async openGlobalGraph(path: string | undefined = undefined) {
+    async openGlobalGraph(options: Partial<IJugglSettings> = {}) {
       const leaf = this.app.workspace.getLeaf(false);
-      const settings = Object.assign({}, this.settings.globalGraphSettings);
-      if (path) {
-        settings.filter = "path:" + path;
-      }
+      const settings = Object.assign({}, this.settings.globalGraphSettings, options);
       // const query = this.localNeighborhoodCypher(name);
       const names = this.app.vault.getFiles().map((f) => f.extension === 'md'? f.basename : f.name);
       if (names.length > 250) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -121,6 +121,8 @@ export default class JugglPlugin extends Plugin implements IJugglPlugin {
               .onClick((evt) => {
                 if (file.extension === 'md') {
                   this.openLocalGraph(file.basename);
+                } else if (file.extension === undefined) {
+                  this.openGlobalGraph(file.path);
                 } else {
                   this.openLocalGraph(file.name);
                 }
@@ -277,19 +279,23 @@ export default class JugglPlugin extends Plugin implements IJugglPlugin {
       await leaf.open(neovisView);
     }
 
-    async openGlobalGraph() {
+    async openGlobalGraph(path: string | undefined = undefined) {
       const leaf = this.app.workspace.getLeaf(false);
+      const settings = Object.assign({}, this.settings.globalGraphSettings);
+      if (path) {
+        settings.filter = "path:" + path;
+      }
       // const query = this.localNeighborhoodCypher(name);
       const names = this.app.vault.getFiles().map((f) => f.extension === 'md'? f.basename : f.name);
       if (names.length > 250) {
         const modal = new GlobalWarningModal(this.app, async () => {
-          const neovisView = new JugglView(leaf, this.settings.globalGraphSettings, this, names);
+          const neovisView = new JugglView(leaf, settings, this, names);
           await leaf.open(neovisView);
           modal.close();
         });
         modal.open();
       } else {
-        const neovisView = new JugglView(leaf, this.settings.globalGraphSettings, this, names);
+        const neovisView = new JugglView(leaf, settings, this, names);
         await leaf.open(neovisView);
       }
     }


### PR DESCRIPTION
Before it would open a local graph on that folder, which is not a thing so nothing would show. Now it opens a global graph but only shows nodes within that folder.